### PR TITLE
feat: Queue "cached" commands if its execution timed out

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -22,3 +22,7 @@ export function OperationTimeoutError(timeout: number): Error {
 
   return customError(ERRORS.OperationTimeoutError, text);
 }
+
+export function isOperationTimeoutError(error: any): boolean {
+  return error instanceof Error && error.name === ERRORS.OperationTimeoutError;
+}


### PR DESCRIPTION
If called "cached" command fails with `OperationTimeoutError` it should be queued like if the connection was absent at all.