### PR TITLE
ci: do not persist temporary github token on checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v1.4.2


### PR DESCRIPTION
It prevents semantic-release to use GITHUB_TOKEN env variable.